### PR TITLE
Args to expand formatting of ticket name

### DIFF
--- a/giticket/giticket.py
+++ b/giticket/giticket.py
@@ -14,7 +14,7 @@ underscore_split_mode = 'underscore_split'
 regex_match_mode = 'regex_match'
 
 
-def update_commit_message(filename, regex, mode, format_string):
+def update_commit_message(filename, regex, mode, format_string, divider, divider_offset):
     with io.open(filename, 'r+') as fd:
         contents = fd.readlines()
         commit_msg = contents[0].rstrip('\r\n')
@@ -29,7 +29,12 @@ def update_commit_message(filename, regex, mode, format_string):
         if tickets:
             if mode == underscore_split_mode:
                 tickets = [branch.split(six.text_type('_'))[0]]
-            tickets = [t.strip() for t in tickets]
+
+            if divider:
+                # Example: Expand PRO123 -> PRO-123
+                tickets = [divider not in t and f"{t.strip()[0:divider_offset]}{divider}{t.strip()[divider_offset:]}" or t.strip() for t in tickets]
+            else:
+                tickets = [t.strip() for t in tickets]
 
             new_commit_msg = format_string.format(
                 ticket=tickets[0], tickets=', '.join(tickets),
@@ -60,18 +65,24 @@ def main(argv=None):
 
         - The ticket format regex specified must match.
         - The branch name format must be <ticket number>_<rest of the branch name>
+        - Setting 'divider' and 'divider_offset' can be used to expand PROJECT123 to PROJECT-123 or PROJECT::123
     """
     parser = argparse.ArgumentParser()
+    # Required #
     parser.add_argument('filenames', nargs='+')
+    # Optional #
     parser.add_argument('--regex')
     parser.add_argument('--format')
+    parser.add_argument('--divider')
+    parser.add_argument('--divider_offset', type=int, default=3)
     parser.add_argument('--mode', nargs='?', const=underscore_split_mode,
                         default=underscore_split_mode,
                         choices=[underscore_split_mode, regex_match_mode])
     args = parser.parse_args(argv)
     regex = args.regex or r'[A-Z]+-\d+'  # noqa
-    format_string = args.format or '{ticket} {commit_msg}' # noqa
-    update_commit_message(args.filenames[0], regex, args.mode, format_string)
+    format_string = args.format or '{ticket} {commit_msg}'  # noqa
+    divider_offset = args.divider_offset
+    update_commit_message(args.filenames[0], regex, args.mode, format_string, args.divider, divider_offset)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adding args:
- 'divider'
- and 'divider_offset'

Which can be used to expand `PROJECT123` to `PROJECT-123` or `PROJECT::123`.

Example, instead of having branch name:
```PROJ-123_other_details_here```
you can shorten your branch name to:
```PROJ123_other_details_here```

Then update your config to:
```
repos:
  - repo: https://github.com/MVV90/giticket
    rev: v1.3
    hooks:
    - id: giticket
      args: ['--mode=regex_match', '--regex=PROJ(?:\-|\_|)\d+', '--divider=-', '--divider_offset=4', '--format=[{ticket}] {commit_msg}']
```

Which will be expands commits from `PROJ123` to `PROJ-123`
